### PR TITLE
Flavio dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile to build all the available variants
 
-BUILDS = opencvfft-st opencvfft-async opencvfft-openmp fftw fftw-async fftw-openmp fftw-big fftw-big-openmp cufftw cufftw-big cufftw-big-openmp cufft cufft-openmp cufft-big cufft-big-openmp
+BUILDS = opencvfft-st opencvfft-async opencvfft-openmp fftw fftw-async fftw-openmp fftw-big fftw-big-openmp cufftw cufftw-big cufftw-big-openmp cufft cufft-openmp cufft-big cufft-big-openmp cufft-trad cufft-openmp-trad cufft-big-trad cufft-big-openmp-trad
 TESTSEQ = bmx ball1 crossing racing book
 TESTFLAGS = default fit
 
@@ -27,21 +27,25 @@ clean: build.ninja
 # export CUDA_BIN_PATH=/usr/local/cuda-9.0
 # export CUDA_ARCH_LIST=6.2
 
-CMAKE_OTPS_opencvfft-st      = -DFFT=OpenCV
-CMAKE_OTPS_opencvfft-async   = -DFFT=OpenCV -DASYNC=ON
-CMAKE_OTPS_opencvfft-openmp  = -DFFT=OpenCV -DOPENMP=ON
-CMAKE_OTPS_fftw              = -DFFT=fftw
-CMAKE_OTPS_fftw-openmp       = -DFFT=fftw -DOPENMP=ON
-CMAKE_OTPS_fftw-async        = -DFFT=fftw -DASYNC=ON
-CMAKE_OTPS_fftw-big          = -DFFT=fftw -DBIG_BATCH=ON
-CMAKE_OTPS_fftw-big-openmp   = -DFFT=fftw -DBIG_BATCH=ON -DOPENMP=ON
-CMAKE_OTPS_cufftw            = -DFFT=cuFFTW $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)')
-CMAKE_OTPS_cufftw-big        = -DFFT=cuFFTW $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON
-CMAKE_OTPS_cufftw-big-openmp = -DFFT=cuFFTW $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON -DOPENMP=ON
-CMAKE_OTPS_cufft             = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)')
-CMAKE_OTPS_cufft-openmp	     = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DOPENMP=ON
-CMAKE_OTPS_cufft-big         = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON
-CMAKE_OTPS_cufft-big-openmp  = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON -DOPENMP=ON
+CMAKE_OTPS_opencvfft-st           = -DFFT=OpenCV
+CMAKE_OTPS_opencvfft-async        = -DFFT=OpenCV -DASYNC=ON
+CMAKE_OTPS_opencvfft-openmp       = -DFFT=OpenCV -DOPENMP=ON
+CMAKE_OTPS_fftw                   = -DFFT=fftw
+CMAKE_OTPS_fftw-openmp            = -DFFT=fftw -DOPENMP=ON
+CMAKE_OTPS_fftw-async             = -DFFT=fftw -DASYNC=ON
+CMAKE_OTPS_fftw-big               = -DFFT=fftw -DBIG_BATCH=ON
+CMAKE_OTPS_fftw-big-openmp        = -DFFT=fftw -DBIG_BATCH=ON -DOPENMP=ON
+CMAKE_OTPS_cufftw                 = -DFFT=cuFFTW $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)')
+CMAKE_OTPS_cufftw-big             = -DFFT=cuFFTW $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON
+CMAKE_OTPS_cufftw-big-openmp      = -DFFT=cuFFTW $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON -DOPENMP=ON
+CMAKE_OTPS_cufft                  = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)')
+CMAKE_OTPS_cufft-openmp           = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DOPENMP=ON
+CMAKE_OTPS_cufft-big              = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON
+CMAKE_OTPS_cufft-big-openmp       = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON -DOPENMP=ON
+CMAKE_OTPS_cufft-trad             = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DUSE_CUDA_MEMCPY=ON
+CMAKE_OTPS_cufft-openmp-trad      = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DOPENMP=ON -DUSE_CUDA_MEMCPY=ON
+CMAKE_OTPS_cufft-big-trad         = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON -DUSE_CUDA_MEMCPY=ON
+CMAKE_OTPS_cufft-big-openmp-trad  = -DFFT=cuFFT  $(if $(CUDA_ARCH_LIST),-DCUDA_ARCH_LIST='$(CUDA_ARCH_LIST)') -DBIG_BATCH=ON -DOPENMP=ON -DUSE_CUDA_MEMCPY=ON
 
 ##########################
 ### Tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ option(OPENMP "Use OpenMP to paralelize certain portions of code." OFF)
 option(ASYNC "Use C++ std::async to paralelize certain portions of code." OFF)
 option(CUDA_DEBUG "Enables error cheking for cuda and cufft. " OFF)
 option(BIG_BATCH "Execute all FFT calculation in a single batch. This can improve paralelism and reduce GPU offloading overhead." OFF)
+option(USE_CUDA_MEMCPY "Use the normal CUDA memory model with CUDA memcopy operations to move to and from the device." OFF)
 
 IF(PROFILING)
   add_definitions(-DPROFILING )
@@ -21,6 +22,15 @@ ENDIF()
 IF(BIG_BATCH)
   add_definitions(-DBIG_BATCH )
   MESSAGE(STATUS "Big_batch mode")
+ENDIF()
+
+IF( NOT (FFT STREQUAL "cuFFT") AND USE_CUDA_MEMCPY)
+  message(SEND_ERROR "CUDA traditional memory opperations are only supported in combination with cuFFT")
+ENDIF()
+
+IF(USE_CUDA_MEMCPY)
+  add_definitions(-DUSE_CUDA_MEMCPY )
+  MESSAGE(STATUS "CUDA using memcpy operations")
 ENDIF()
 
 IF (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") AND NOT OPENMP)

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -14,6 +14,19 @@ std::ostream &operator<<(std::ostream &os, const DbgTracer::Printer<cv::Mat> &p)
     return os;
 }
 
+std::ostream &operator<<(std::ostream &os, const DbgTracer::Printer<MatDynMem> &p)
+{
+    IOSave s(os);
+    os << std::setprecision(DbgTracer::precision);
+    os << p.obj.size << " " << p.obj.channels() << "ch ";// << static_cast<const void *>(p.obj.data);
+    os << " = [ ";
+    const size_t num = 10; //p.obj.total();
+    for (size_t i = 0; i < std::min(num, p.obj.total()); ++i)
+        os << p.obj.hostMem()[i] << ", ";
+    os << (num < p.obj.total() ? "... ]" : "]");
+    return os;
+}
+
 std::ostream &operator<<(std::ostream &os, const DbgTracer::Printer<ComplexMat> &p)
 {
     IOSave s(os);

--- a/src/debug.h
+++ b/src/debug.h
@@ -95,9 +95,9 @@ class DbgTracer {
     };
 
     template <typename T> Printer<T> print(const T& obj) { return Printer<T>(obj); }
-    Printer<cv::Mat> print(const MatScales& obj) { return Printer<cv::Mat>(obj); }
-    Printer<cv::Mat> print(const MatFeats& obj) { return Printer<cv::Mat>(obj); }
-    Printer<cv::Mat> print(const MatScaleFeats& obj) { return Printer<cv::Mat>(obj); }
+    Printer<MatDynMem> print(const MatScales& obj) { return Printer<MatDynMem>(obj); }
+    Printer<MatDynMem> print(const MatFeats& obj) { return Printer<MatDynMem>(obj); }
+    Printer<MatDynMem> print(const MatScaleFeats& obj) { return Printer<MatDynMem>(obj); }
 };
 
 template <typename T>
@@ -131,6 +131,7 @@ static inline std::ostream &operator<<(std::ostream &os, const cufftComplex &p)
 #endif
 
 std::ostream &operator<<(std::ostream &os, const DbgTracer::Printer<ComplexMat> &p);
+std::ostream &operator<<(std::ostream &os, const DbgTracer::Printer<MatDynMem> &p);
 
 extern DbgTracer __dbgTracer;
 

--- a/src/fft_cufft.cpp
+++ b/src/fft_cufft.cpp
@@ -76,7 +76,6 @@ void cuFFT::forward_window(MatScaleFeats &feat, ComplexMat &complex_result, MatS
 {
     Fft::forward_window(feat, complex_result, temp);
 
-    cufftReal *temp_data = temp.deviceMem();
     uint n_scales = feat.size[0];
 
     for (uint s = 0; s < n_scales; ++s) {
@@ -87,6 +86,7 @@ void cuFFT::forward_window(MatScaleFeats &feat, ComplexMat &complex_result, MatS
         }
     }
 
+    cufftReal *temp_data = temp.deviceMem();
     if (n_scales == 1)
         cudaErrorCheck(cufftExecR2C(plan_fw, temp_data, complex_result.get_dev_data()));
 #ifdef BIG_BATCH


### PR DESCRIPTION
CUDA Traditional memory

- Struct is now passed to memorymanager
- Use memory manager with all versions
    - This simplifies macro handling if traditional CUDA memory operations are taken into account
- MemLoc currLoc is mutable to allow modifications from const memberfunctions
- Overwriting ptr member functions in MatDynMem
    - This will be needed for debug output in next commit
- Removed some explicit copy operations since its now done in ptr functions
- Added build configuration

Changed debug output to copy data to host first
