### PR TITLE
Predběžný nástřel na přenesení ComplexMat do třídy Model

### DIFF
--- a/src/kcf.h
+++ b/src/kcf.h
@@ -183,13 +183,20 @@ private:
             }
         }
         
-        // DEFINE (=copy definition of) THIS BLOCK IN kcf.cpp
-        // T type in sqr_norm() is constant defined as float
-        float sqr_norm() const;        
-        void sqr_norm(DynMem_<T> &result) const;
+        // This computes a float value using elements in individual channels
+        float sqr_norm(cv::Mat &host) const; 
+        
+        // This edits given Dynmem to contain computed float value in its [1] position (why?)
+        void sqr_norm(DynMem_<T> &result, cv::Mat &host) const;
+        
+        // Applies square operation to all elements in all channels
         cv::Mat sqr_mag() const;
+        
+        // Applies "invert imaginary number" operation to all elements in all channels
         cv::Mat conj() const;
-        cv::Mat sum_over_channels() const;
+        
+        // DEFINE (=copy definition of) THIS BLOCK IN kcf.cpp 
+        cv::Mat sum_over_channels(cv::Mat &host) const;
         
         //------
         // to_cv_mat() and channel_to_cv_mat() unnecesary, since the data is already cv::Mat format
@@ -221,7 +228,7 @@ private:
         }
         
         //------
-        // operator functions implemented in cv::Mat
+        // operator and mul() functions implemented in cv::Mat
         //------
         
         // READY FOR TESTING
@@ -240,6 +247,7 @@ private:
         }
         
         // DEFINE (=copy definition of) THIS BLOCK IN kcf.cpp
+        // [ possibly completely replaced by cv::Mat.forEach() ]
         ComplexMat_ mat_mat_operator(void (*op)(std::complex<T> &c_lhs, const std::complex<T> &c_rhs),
                                      const ComplexMat_ &mat_rhs) const;
         ComplexMat_ matn_mat1_operator(void (*op)(std::complex<T> &c_lhs, const std::complex<T> &c_rhs),

--- a/src/kcf.h
+++ b/src/kcf.h
@@ -149,7 +149,6 @@ private:
         //START OF TEST COMPLEXMAT CONVERSION
         //-------------------------------------------
         
-        //consider converting to cv::Mat_< std::complex<float> >
         cv::Mat yf_Test {height, width, CV_32FC1};
         cv::Mat model_alphaf_Test {height, width, CV_32FC1};
         cv::Mat model_alphaf_num_Test {height, width, CV_32FC1};
@@ -157,7 +156,7 @@ private:
         cv::Mat model_xf_Test {height, width, CV_32FC(n_feats)};
         cv::Mat xf_Test {height, width, CV_32FC(n_feats)};
 
-        
+        // READY FOR TESTING
         static cv::Mat same_size(const cv::Mat &o)
         {
             return cv::Mat(o.rows, o.cols, o.channels());
@@ -167,60 +166,37 @@ private:
         //size() and channel() already implemented in cv::Mat
         //------
         
+        // READY FOR TESTING
+        // assuming that mat has 2 channels (real, imag)
         void set_channel(uint idx, const cv::Mat &mat, cv::Mat &host)
         {
             assert(idx < host.channels());
             //TODO, part of complexmat.hpp
             cudaSync();
+            
             for (uint i = 0; i < host.rows; ++i) {
-                const std::complex<T> *row = mat.ptr<std::complex<T>>(i);
-                for (uint j = 0; j < host.cols; ++j)
-                    //TODO (study its purpose, replace p_data)
-                    //idx = likely channel number
-                    //made for cv::Mat with 2+ channels (so i probably dont need std::complex<float> ? [yes])
-                    //just put it in the premade channel in cv::Mat as needed
-                    //
-                    //EDIT: consider using this to access and write to channels:
-                    // m.at<Vec2f>( row, col )[0] = 1986.0f;
-                    // m.at<Vec2f>( row, col )[1] = 326.0f;
-                    p_data.hostMem()[idx * host.rows * host.cols + i * host.cols + j] = row[j];
+                const std::complex<float> *row = mat.ptr<std::complex<float>>(i);
+                const std::complex<float> *host_ptr = host.ptr<std::complex<float>>(i);
+                for (uint j = 0; j < cols; ++j)
+                    // Can I actually assign like this? Test it.
+                    host_ptr[j] = std::complex<float>(row[j]);
             }
         }
         
-        //------------------
-        // YET TO BE EDITED
-        //------------------
-        
-        // T is constant defined as float
-        float sqr_norm() const;
-        
+        // DEFINE (=copy definition of) THIS BLOCK IN kcf.cpp
+        // T type in sqr_norm() is constant defined as float
+        float sqr_norm() const;        
         void sqr_norm(DynMem_<T> &result) const;
-
         cv::Mat sqr_mag() const;
-
         cv::Mat conj() const;
-
         cv::Mat sum_over_channels() const;
         
-        // return 2 channels (real, imag) for first complex channel
-        cv::Mat to_cv_mat() const
-        {
-            assert(p_data.num_elem >= 1);
-            return channel_to_cv_mat(0);
-        }
+        //------
+        // to_cv_mat() and channel_to_cv_mat() unnecesary, since the data is already cv::Mat format
+        //------
         
-        cv::Mat channel_to_cv_mat(int channel_id) const
-        {
-            cv::Mat result(rows, cols, CV_32FC2);
-            for (uint y = 0; y < rows; ++y) {
-                std::complex<T> *row_ptr = result.ptr<std::complex<T>>(y);
-                for (uint x = 0; x < cols; ++x) {
-                    row_ptr[x] = p_data[channel_id * rows * cols + y * cols + x];
-                }
-            }
-            return result;
-        }
         
+        // DECIDE IF THIS IS ACTUALLY NEEDED WITH CURRENT cv::Mat FORMAT
         // return a vector of 2 channels (real, imag) per one complex channel
         std::vector<cv::Mat> to_cv_mat_vector() const
         {
@@ -248,20 +224,22 @@ private:
         // operator functions implemented in cv::Mat
         //------
         
+        // READY FOR TESTING
         // convert 2 channel mat (real, imag) to vector row-by-row
-        std::vector<std::complex<T>> convert(const cv::Mat &mat)
+        std::vector<std::complex<float>> convert(const cv::Mat &mat)
         {
-            std::vector<std::complex<T>> result;
+            std::vector<std::complex<float>> result;
             result.reserve(mat.cols * mat.rows);
             for (int y = 0; y < mat.rows; ++y) {
-                const T *row_ptr = mat.ptr<T>(y);
+                const float *row_ptr = mat.ptr<float>(y);
                 for (int x = 0; x < 2 * mat.cols; x += 2) {
-                    result.push_back(std::complex<T>(row_ptr[x], row_ptr[x + 1]));
+                    result.push_back(std::complex<float>(row_ptr[x], row_ptr[x + 1]));
                 }
             }
             return result;
         }
         
+        // DEFINE (=copy definition of) THIS BLOCK IN kcf.cpp
         ComplexMat_ mat_mat_operator(void (*op)(std::complex<T> &c_lhs, const std::complex<T> &c_rhs),
                                      const ComplexMat_ &mat_rhs) const;
         ComplexMat_ matn_mat1_operator(void (*op)(std::complex<T> &c_lhs, const std::complex<T> &c_rhs),
@@ -269,7 +247,6 @@ private:
         ComplexMat_ matn_mat2_operator(void (*op)(std::complex<T> &c_lhs, const std::complex<T> &c_rhs),
                                        const ComplexMat_ &mat_rhs) const;
         ComplexMat_ mat_const_operator(const std::function<void(std::complex<T> &c_rhs)> &op) const;
-        
         void cudaSync() const {}
         
         //-------------------------------------------


### PR DESCRIPTION
Zatím neotestováno, míněno jako náhled průběhu práce. 
Téma viz. předmět pull requestu.

Změna proměnných třídy Model z ComplexMat na cv::Mat .
Funkce které byly původně v třídě ComplexMat přeneseny do třídy Model.
Tyto funkce dostanou podle potřeby jeden nový argument typu cv::Mat, který bude cílem zpracování (tyto argumenty jsou nově upravené proměnné třídy Model).
Po dokončení přenesení funkcí budou vyhledána volání původních funkcí ComplexMat v kódu, a přepsána aby pracovala s nově upravenými funkcemi.

Plánuju teď jako další krok definovat funkce které nebyly definovány v hlavičce (tzn. definice v .cpp).
Až se budu moct dostat do kanceláře, začnu testovat přenesené funkce a upravovat jejich volání v kódu.